### PR TITLE
Fixes alt-tab crash when the chatbox is open.

### DIFF
--- a/P3D/Network/ChatScreen.vb
+++ b/P3D/Network/ChatScreen.vb
@@ -1,3 +1,5 @@
+Imports P3D.BattleSystem.Moves.Water
+
 Public Class ChatScreen
 
     Inherits Screen
@@ -88,6 +90,10 @@ Public Class ChatScreen
         'Crops too long input text:
         If FontManager.TextFont.MeasureString(Me.currentText).X * 2.0F > Core.windowSize.Width - 200 Then
             While FontManager.TextFont.MeasureString(Me.currentText).X * 2.0F > Core.windowSize.Width - 200
+                If Me.currentText.Length = 0 Then
+                    Exit While
+                End If
+
                 Me.currentText = Me.currentText.Remove(Me.currentText.Length - 1, 1)
             End While
         End If

--- a/P3D/Network/ChatScreen.vb
+++ b/P3D/Network/ChatScreen.vb
@@ -1,5 +1,3 @@
-Imports P3D.BattleSystem.Moves.Water
-
 Public Class ChatScreen
 
     Inherits Screen


### PR DESCRIPTION
The game is prone to some form of bugs when chatbox is open and alt-tabbing kills it. This prevent the chatbox from removing empty text by exiting the while loop if the text is already empty.